### PR TITLE
Update Default Branch for Deployment Workflow #8

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches:
-      - "deploy/v1.0.0"
+      - "deploy/v1.1.0"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -54,6 +54,13 @@ jobs:
         with:
           node-version: "lts/*"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
+      - name: Make envfile
+        uses: SpicyPizza/create-envfile@v1  
+        with: 
+          envkey_NEXT_PUBLIC_SEPOLIA_INFURA_NODEY: ${{ secrets.NEXT_PUBLIC_SEPOLIA_INFURA_NODE }}
+          envkey_NEXT_PUBLIC_DEVELOPMENT: false
+          file_name: .env.local
+          directory: ./ 
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Restore cache


### PR DESCRIPTION
- Changed the default branch reference in the deployment workflow from "deploy/v1.0.0" to "deploy/v1.1.0".
- Added a step to create an environment file using SpicyPizza/create-envfile.
  - Set environment variables for NEXT_PUBLIC_SEPOLIA_INFURA_NODEY and NEXT_PUBLIC_DEVELOPMENT.
  - Created the .env.local file in the specified directory.